### PR TITLE
Add required_ruby_version to gemspec

### DIFF
--- a/referral.gemspec
+++ b/referral.gemspec
@@ -18,9 +18,11 @@ Gem::Specification.new do |spec|
   spec.files = Dir.chdir(File.expand_path("..", __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+
+  spec.bindir      = "exe"
+  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+
+  spec.required_ruby_version = '>= 2.6.0'
 
   spec.add_development_dependency "bundler", "~> 1.17.3"
   spec.add_development_dependency "rake", "~> 12.3"


### PR DESCRIPTION
At the moment if you install referral with an invalid version of Ruby you get something like this:

`Error: referral must be run with Ruby 2.6 or later, but this is 2.5.5`

So, rather than telling me only after I've installed it, let's set that up front via the gemspec.

Also, you don't need to set 'lib' for the `require_paths`, that's the default.