### PR TITLE
Why does adding a field to the token break so many tests?

### DIFF
--- a/lib/referral/value/token.rb
+++ b/lib/referral/value/token.rb
@@ -3,7 +3,7 @@ require "digest/sha1"
 module Referral
   module Value
     class Token < Struct.new(
-      :name, :identifiers, :node_type, :parent, :file, :line, :column,
+      :name, :identifiers, :node_type, :parent, :file, :line, :column, :arity,
       keyword_init: true
     )
 


### PR DESCRIPTION
This causes 3 tests in cli.test to fail.  It appears to change the order
of evaluation???  I'm thoroughly confused.

@searls - no rush on this.   If you have a chance to pair up or provide some context async, I'd appreciate it.  I don't understand this at all.