### PR TITLE
Allow filtering by arity

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,23 @@ app/lib/presents_review_result.rb:60:2: 2019-06-02T02:38:01Z   def item_result(s
 
 `find` couldn't have told me that (I don't think)!
 
+### Recipe:  Find calls that have more than 1 argument
+
+[Recently I was upgrading the i18n gem](http://blog.testdouble.com/posts/2019-10-15-lets-hash-this-out/) and came across some bugs introduced by [this change](https://github.com/ruby-i18n/i18n/commit/5eeaad7fb35f9a30f654e3bdeb6933daa7fd421d#diff-14d9864ac07456d554843dc2a3b174a4L179). To fix the issue, I started looking at all the places `I18n.t` was called from:
+
+```
+referral --type call --exact-name I18n.t -c location,source
+```
+
+Unfortunately, this produces 250+ false positives because the predominant usage was to pass a single argument to `t`. Only calls with more than 1 argument are affected by this change. `--pattern` doesn't work very well in this codebase, because calls to `t` with multiple arguments are more likely to be multiline.
+
+```
+referral --type call --exact-name I18n.t --arity 2+ -c location,source,arity
+```
+
+This produced 27 results I could quickly skim through.
+
+
 ## Options
 
 Referral provides a lot of options. The help output of `referral --help` will
@@ -219,6 +236,7 @@ Usage: referral [options] files
         --scope [SCOPE]              Scope(s) in which to filter (e.g. Hastack#hide)
     -p, --pattern [PATTERN]          Regex pattern to filter
     -t, --type [TYPES]               Include only certain types. See Referral::TOKEN_TYPES.
+        --arity [ARITY]              Number of arguments to a method call.  (e.g. 2+)
         --include-unnamed            Include reference without identifiers (default: false)
     -s, --sort {file,scope}          (default: file). See Referral::SORT_FUNCTIONS
         --print-headers              Print header names (default: false)
@@ -230,6 +248,8 @@ A few things to note:
 
 * Each of `--name`, `--exact-name`, `--full-name`, `--scope`, `--type`, and `--columns`
   accept comma-separated arrays (e.g. `--name foo,bar,baz`)
+
+* `--arity` supports a single digit with an optional `+`.  e.g. `--arity 0` or `--arity 1+`
 
 * You can browse available sort functions [in
   Referral::SORT_FUNCTIONS](/lib/referral/sorts_tokens.rb) for use with

--- a/README.md
+++ b/README.md
@@ -249,7 +249,10 @@ A few things to note:
 * Each of `--name`, `--exact-name`, `--full-name`, `--scope`, `--type`, and `--columns`
   accept comma-separated arrays (e.g. `--name foo,bar,baz`)
 
-* `--arity` supports a single digit with an optional `+`.  e.g. `--arity 0` or `--arity 1+`
+* `--arity` accepts a number with an optional `+` or `-`.
+  *  `--arity 0`  Match calls with 0 arguments
+  *  `--arity 1+` Match calls with 1 or more arguments
+  *  `--arity 1-` Match calls with 1 or fewer arguments
 
 * You can browse available sort functions [in
   Referral::SORT_FUNCTIONS](/lib/referral/sorts_tokens.rb) for use with

--- a/lib/referral/filters_tokens.rb
+++ b/lib/referral/filters_tokens.rb
@@ -40,6 +40,8 @@ module Referral
         false
       elsif arity.end_with? "+"
         token.arity.to_i >= arity.to_i
+      elsif arity.end_with? "-"
+        token.arity.to_i <= arity.to_i
       else
         token.arity.to_i == arity.to_i
       end

--- a/lib/referral/filters_tokens.rb
+++ b/lib/referral/filters_tokens.rb
@@ -35,6 +35,15 @@ module Referral
         true
       end
     },
+    arity: -> (token, arity) {
+      if token.arity.nil?
+        false
+      elsif arity.end_with? "+"
+        token.arity.to_i >= arity.to_i
+      else
+        token.arity.to_i == arity.to_i
+      end
+    },
   }
   class FiltersTokens
     def call(tokens, options)

--- a/lib/referral/parses_options.rb
+++ b/lib/referral/parses_options.rb
@@ -25,6 +25,7 @@ module Referral
         op.on("--scope [SCOPE]", Array, "Scope(s) in which to filter (e.g. Hastack#hide)")
         op.on("-p", "--pattern [PATTERN]", Regexp, "Regex pattern to filter")
         op.on("-t", "--type [TYPES]", Array, "Include only certain types. See Referral::TOKEN_TYPES.")
+        op.on("--arity [ARITY]", "Number of arguments to a method call.  (e.g. 2+)")
         op.on("--include-unnamed", TrueClass, "Include reference without identifiers (default: false)")
         op.on("-s", "--sort {file,scope}", "(default: file). See Referral::SORT_FUNCTIONS")
         op.on("--print-headers", TrueClass, "Print header names (default: false)")

--- a/lib/referral/prints_results.rb
+++ b/lib/referral/prints_results.rb
@@ -43,6 +43,9 @@ module Referral
     git_commit_at: ->(token) {
       GitStore.time(token.file, token.line)&.utc&.iso8601
     },
+    arity: ->(token) {
+      token.arity
+    },
 
   }
 

--- a/lib/referral/token_types.rb
+++ b/lib/referral/token_types.rb
@@ -108,7 +108,8 @@ module Referral
       token_type: :reference,
       reverse_identifiers: true,
       good_parent: true,
-      name_finder: ->(node) { node.children[1] }
+      name_finder: ->(node) { node.children[1] },
+      arity_finder: ->(node) { node.children.last&.children&.compact&.count || 0 }
     ),
     function_call: Value::NodeType.new(
       name: :function_call,
@@ -117,7 +118,8 @@ module Referral
       token_type: :reference,
       reverse_identifiers: true,
       good_parent: false,
-      name_finder: ->(node) { node.children[0] }
+      name_finder: ->(node) { node.children[0] },
+      arity_finder: ->(node) { node.children.last&.children&.compact&.count || 0 }
     ),
     local_var: Value::NodeType.new(
       name: :local_var,

--- a/lib/referral/translates_node_to_token.rb
+++ b/lib/referral/translates_node_to_token.rb
@@ -12,7 +12,8 @@ module Referral
         parent: parent,
         file: file,
         line: node.first_lineno,
-        column: node.first_column
+        column: node.first_column,
+        arity: type&.arity_finder&.call(node)
       )
     end
   end

--- a/lib/referral/value/node_type.rb
+++ b/lib/referral/value/node_type.rb
@@ -8,6 +8,7 @@ module Referral
       :token_type,
       :reverse_identifiers,
       :good_parent,
+      :arity_finder,
       keyword_init: true
     )
     end

--- a/lib/referral/value/options.rb
+++ b/lib/referral/value/options.rb
@@ -10,6 +10,7 @@ module Referral
       :pattern,
       :type,
       :include_unnamed,
+      :arity,
       # Sorting
       :sort,
       # Printing

--- a/lib/referral/value/token.rb
+++ b/lib/referral/value/token.rb
@@ -3,7 +3,7 @@ require "digest/sha1"
 module Referral
   module Value
     class Token < Struct.new(
-      :name, :identifiers, :node_type, :parent, :file, :line, :column,
+      :name, :identifiers, :node_type, :parent, :file, :line, :column, :arity,
       keyword_init: true
     )
 

--- a/test/fixture/9.rb
+++ b/test/fixture/9.rb
@@ -1,0 +1,8 @@
+def call_me_maybe
+  friday!
+  blue(1, "fish", 2, "fish")
+  hey.macarena(1993)
+  barbie_girl(by: :aqua, in_a: "barbie world")
+  mmmbop(1997, brother_count: 3)
+  _chumbawamba = "Tubthmping"
+end

--- a/test/referral/arity_test.rb
+++ b/test/referral/arity_test.rb
@@ -1,0 +1,82 @@
+require "test_helper"
+require "referral/translates_node_to_token"
+
+module Referral
+  class ArityTest < ReferralTest
+    def translate(node)
+      TranslatesNodeToToken.new.call(node, nil, "foo.rb")
+    end
+
+    def test_call_ignore_arity
+      node = RubyVM::AbstractSyntaxTree.parse <<~RUBY
+        foo(a, b)
+      RUBY
+      root_node = node.children.last
+      token = translate(root_node)
+      assert_equal TOKEN_TYPES[:function_call], token.node_type
+    end
+
+    def test_call_arity0
+      node = RubyVM::AbstractSyntaxTree.parse <<~RUBY
+        foo()
+      RUBY
+      root_node = node.children.last
+      token = translate(root_node)
+      assert_equal 0, token.arity
+    end
+
+    def test_call_arity1
+      node = RubyVM::AbstractSyntaxTree.parse <<~RUBY
+        foo a
+      RUBY
+      root_node = node.children.last
+      token = translate(root_node)
+      assert_equal 1, token.arity
+    end
+
+    def test_call_arity2
+      node = RubyVM::AbstractSyntaxTree.parse <<~RUBY
+        foo(a, b)
+      RUBY
+      root_node = node.children.last
+      token = translate(root_node)
+      assert_equal 2, token.arity
+    end
+
+    def test_member_call_arity
+      node = RubyVM::AbstractSyntaxTree.parse <<~RUBY
+        bar.foo(a, b, c)
+      RUBY
+      root_node = node.children.last
+      token = translate(root_node)
+      assert_equal 3, token.arity
+    end
+
+    def test_class_call_arity
+      node = RubyVM::AbstractSyntaxTree.parse <<~RUBY
+        BAR::foo(a, b, c, d)
+      RUBY
+      root_node = node.children.last
+      token = translate(root_node)
+      assert_equal 4, token.arity
+    end
+
+    def test_call_kwargs_arity
+      node = RubyVM::AbstractSyntaxTree.parse <<~RUBY
+        foo(a: 1, b: 2)
+      RUBY
+      root_node = node.children.last
+      token = translate(root_node)
+      assert_equal 1, token.arity
+    end
+
+    def test_call_kwargs_and_positional_arity
+      node = RubyVM::AbstractSyntaxTree.parse <<~RUBY
+        foo(a, b: 2, c: 3)
+      RUBY
+      root_node = node.children.last
+      token = translate(root_node)
+      assert_equal 2, token.arity
+    end
+  end
+end

--- a/test/referral/cli_test.rb
+++ b/test/referral/cli_test.rb
@@ -438,5 +438,21 @@ module Referral
         9.rb:2:2: function_call call_me_maybe friday!
       RUBY
     end
+
+    def test_arity_output
+      fake_out, fake_err, _ = do_with_fake_io(cwd: "test/fixture") {
+        Cli.new(%w[-c arity,source 9.rb]).call
+      }
+      assert_empty fake_err.string
+      assert_equal <<~RUBY, fake_out.string
+         def call_me_maybe
+        0   friday!
+        4   blue(1, \"fish\", 2, \"fish\")
+        1   hey.macarena(1993)
+        1   barbie_girl(by: :aqua, in_a: \"barbie world\")
+        2   mmmbop(1997, brother_count: 3)
+           _chumbawamba = \"Tubthmping\"
+      RUBY
+    end
   end
 end

--- a/test/referral/cli_test.rb
+++ b/test/referral/cli_test.rb
@@ -269,14 +269,14 @@ module Referral
         b93a495 A::Car class
         8e3cf92 A::Car::THINGS constant_declaration
         c9bcc9c A::Car#vroom! instance_method
-        383a8c3 puts function_call
+        047c53a puts function_call
         ed0a5df A::B module
-        4c27e32 require_relative function_call
+        c577e71 require_relative function_call
         4f0f9a6 car local_var_assign
-        9b0bbd1 A::Car.new call
-        44d6efb puts function_call
+        a220e79 A::Car.new call
+        19a0b90 puts function_call
         debac1a A::Car::THINGS constant
-        a60bed2 car.vroom! call
+        e397cf6 car.vroom! call
       RUBY
     end
 

--- a/test/referral/cli_test.rb
+++ b/test/referral/cli_test.rb
@@ -205,8 +205,8 @@ module Referral
       assert_empty fake_err.string
       assert_equal <<~RUBY, fake_out.string
         2.rb:1:0: function_call  puts
-        2.rb:1:5: call  zap.+
         2.rb:1:5: local_var_assign  zap
+        2.rb:1:5: call  zap.+
         2.rb:3:0: function_call  puts
         2.rb:3:5: call  zip.*
         2.rb:3:5: local_var_assign  zip
@@ -229,8 +229,8 @@ module Referral
       assert_empty fake_err.string
       assert_equal <<~RUBY, fake_out.string
         2.rb:1:0: function_call  puts
-        2.rb:1:5: call  zap.+
         2.rb:1:5: local_var_assign  zap
+        2.rb:1:5: call  zap.+
         2.rb:3:0: function_call  puts
         2.rb:3:5: call  zip.*
         2.rb:3:5: local_var_assign  zip
@@ -265,18 +265,18 @@ module Referral
       }
       assert_empty fake_err.string
       assert_equal <<~RUBY, fake_out.string
-        8157996 A module
-        ce748d5 A::Car class
-        793b0f6 A::Car::THINGS constant_declaration
-        dc3179e A::Car#vroom! instance_method
-        484adc9 puts function_call
-        6074cce A::B module
-        ddd4ecb require_relative function_call
-        a3616b5 car local_var_assign
-        72cfd8c A::Car.new call
-        d0ef0c9 puts function_call
-        7f464ab A::Car::THINGS constant
-        d48d374 car.vroom! call
+        a6fac63 A module
+        b93a495 A::Car class
+        8e3cf92 A::Car::THINGS constant_declaration
+        c9bcc9c A::Car#vroom! instance_method
+        383a8c3 puts function_call
+        ed0a5df A::B module
+        4c27e32 require_relative function_call
+        4f0f9a6 car local_var_assign
+        9b0bbd1 A::Car.new call
+        44d6efb puts function_call
+        debac1a A::Car::THINGS constant
+        a60bed2 car.vroom! call
       RUBY
     end
 

--- a/test/referral/cli_test.rb
+++ b/test/referral/cli_test.rb
@@ -406,5 +406,37 @@ module Referral
         8.rb:20:35: constant Haystack::Deep#find.is_a? Needle
       RUBY
     end
+
+    def test_arity_filter_exact
+      fake_out, fake_err, _ = do_with_fake_io(cwd: "test/fixture") {
+        Cli.new(%w[--arity 1 9.rb]).call
+      }
+      assert_empty fake_err.string
+      assert_equal <<~RUBY, fake_out.string
+        9.rb:4:2: call call_me_maybe macarena
+        9.rb:5:2: function_call call_me_maybe barbie_girl
+      RUBY
+    end
+
+    def test_arity_filter_plus
+      fake_out, fake_err, _ = do_with_fake_io(cwd: "test/fixture") {
+        Cli.new(%w[--arity 2+ 9.rb]).call
+      }
+      assert_empty fake_err.string
+      assert_equal <<~RUBY, fake_out.string
+        9.rb:3:2: function_call call_me_maybe blue
+        9.rb:6:2: function_call call_me_maybe mmmbop
+      RUBY
+    end
+
+    def test_arity_0_only_returns_calls
+      fake_out, fake_err, _ = do_with_fake_io(cwd: "test/fixture") {
+        Cli.new(%w[--arity 0 9.rb]).call
+      }
+      assert_empty fake_err.string
+      assert_equal <<~RUBY, fake_out.string
+        9.rb:2:2: function_call call_me_maybe friday!
+      RUBY
+    end
   end
 end

--- a/test/referral/cli_test.rb
+++ b/test/referral/cli_test.rb
@@ -429,6 +429,18 @@ module Referral
       RUBY
     end
 
+    def test_arity_filter_minus
+      fake_out, fake_err, _ = do_with_fake_io(cwd: "test/fixture") {
+        Cli.new(%w[--arity 1- 9.rb]).call
+      }
+      assert_empty fake_err.string
+      assert_equal <<~RUBY, fake_out.string
+        9.rb:2:2: function_call call_me_maybe friday!
+        9.rb:4:2: call call_me_maybe macarena
+        9.rb:5:2: function_call call_me_maybe barbie_girl
+      RUBY
+    end
+
     def test_arity_0_only_returns_calls
       fake_out, fake_err, _ = do_with_fake_io(cwd: "test/fixture") {
         Cli.new(%w[--arity 0 9.rb]).call

--- a/test/referral/runner_test.rb
+++ b/test/referral/runner_test.rb
@@ -23,22 +23,23 @@ module Referral
       assert_includes tokens, token_for(:THINGS, :constant_def, 11, 4, foo)
       assert_includes tokens, token_for(:foz, :class_method, 13, 4, foo)
       assert_includes tokens, token_for(:fiz, :instance_method, 16, 4, foo)
-      assert_includes tokens, token_for(:baz, :call, 22, 0, nil)
-      assert_includes tokens, a_puts = token_for(:puts, :function_call, 24, 0, nil)
+      assert_includes tokens, token_for(:baz, :call, 22, 0, nil, 0)
+      assert_includes tokens, a_puts = token_for(:puts, :function_call, 24, 0, nil, 1)
       assert_includes tokens, token_for(:THINGS, :double_colon, 24, 8, a_puts)
-      assert_includes tokens, token_for(:fiz, :call, 26, 0, nil)
+      assert_includes tokens, token_for(:fiz, :call, 26, 0, nil, 0)
     end
 
     private
 
-    def token_for(name, type, line, column, parent = nil)
+    def token_for(name, type, line, column, parent = nil, arity = nil)
       Value::Token.new(
         name: name,
         node_type: TOKEN_TYPES[type],
         parent: parent,
         file: @file,
         line: line,
-        column: column
+        column: column,
+        arity: arity
       )
     end
   end


### PR DESCRIPTION
This PR adds the ability to display and filter the number of arguments to a call.

I ended up simply storing the `arity` to a call on the token.  I thought about storing the args as sub-tokens to give more filtering options but it just seemed too complicated to pay off.  

I don't feel great about `arity_finder`. This is only used for calls, so I defaulted to omitting it on most
kind of nodes.  This breaks the declarative pattern in `TokenTypes` somewhat, but adding a bunch of procs that returned `nil` didn't feel great either.

Definitely interested in feedback about passing options to the filter.  Exact match seems pretty reasonable, but not very user-friendly.   "2+" is what I reach for.  I couldn't think of a ubiquitous "1 or less" representation that didn't get into escaping gymnastics in bash 🙅‍♂️`<`🙅‍♂️  .  That said, this sort of thing is a breeze for a spreadsheet, so I'd be ok with omitting it just to keep the syntax weirdness out.  I'm also not sure `arity` is the friendliest name for this field, but it is easy to type.

Closes #7