### PR TITLE
WIP: see what is being returned in actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/lib/referral/git_store.rb
+++ b/lib/referral/git_store.rb
@@ -7,8 +7,11 @@ module Referral
 
     def self.sha(file, line)
       return unless (output = blame_line(file, line))
-      return unless (match = output.match(/^(\w+)/))
-      match[1]
+      if (match = output.match(/^(\w+)/))
+        match[1]
+      else
+        puts "Unexpected Git output: #{output.inspect}"
+      end
     end
 
     def self.author(file, line)

--- a/lib/referral/git_store.rb
+++ b/lib/referral/git_store.rb
@@ -7,7 +7,7 @@ module Referral
 
     def self.sha(file, line)
       return unless (output = blame_line(file, line))
-      if (match = output.match(/^(\w+)/))
+      if (match = output.match(/^\^?(\w+)/))
         match[1]
       else
         puts "Unexpected Git output: #{output.inspect}"

--- a/lib/referral/git_store.rb
+++ b/lib/referral/git_store.rb
@@ -7,11 +7,8 @@ module Referral
 
     def self.sha(file, line)
       return unless (output = blame_line(file, line))
-      if (match = output.match(/^(\w+)/))
-        match[1]
-      else
-        puts "Unexpected Git output: #{output.inspect}"
-      end
+      return unless (match = output.match(/^(\w+)/))
+      match[1]
     end
 
     def self.author(file, line)

--- a/lib/referral/git_store.rb
+++ b/lib/referral/git_store.rb
@@ -7,7 +7,7 @@ module Referral
 
     def self.sha(file, line)
       return unless (output = blame_line(file, line))
-      if (match = output.match(/^\^?(\w+)/))
+      if (match = output.match(/^(\w+)/))
         match[1]
       else
         puts "Unexpected Git output: #{output.inspect}"


### PR DESCRIPTION
My guess is that the Github Action build is failing because the output of `git` has leading blanks or similar. Print it out and see.