### PR TITLE
Ensure Git history is retrieved for testing

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
Without this change, only the most recent commit is checked out and `git blame` gives unexpected output.

Thanks to the replies to @searls who suggested trying options to `actions/checkout`.